### PR TITLE
Add subscriptions support

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,3 +11,11 @@ headers:
     request:
       - propagate:
           named: "Authorization"
+subscription:
+  enabled: true
+  mode:
+    passthrough:
+      all: # The router uses these subscription settings UNLESS overridden per-subgraph
+        path: /graphql # The absolute URL path to use for subgraph subscription endpoints (Default: /ws)
+        protocol: graphql_ws # The WebSocket-based subprotocol to use for subscription communication (Default: graphql_ws)
+        heartbeat_interval: 10s # Optional and 'disable' by default, also supports 'enable' (set 5s interval) and custom values for intervals, e.g. '100ms', '10s', '1m'.

--- a/config.yaml
+++ b/config.yaml
@@ -18,4 +18,3 @@ subscription:
       all: # The router uses these subscription settings UNLESS overridden per-subgraph
         path: /graphql # The absolute URL path to use for subgraph subscription endpoints (Default: /ws)
         protocol: graphql_ws # The WebSocket-based subprotocol to use for subscription communication (Default: graphql_ws)
-        heartbeat_interval: 10s # Optional and 'disable' by default, also supports 'enable' (set 5s interval) and custom values for intervals, e.g. '100ms', '10s', '1m'.


### PR DESCRIPTION
Adding support for subscriptions to the iOS Workshop Router instance. I've followed the [config docs](https://www.apollographql.com/docs/router/executing-operations/subscription-support/#websocket-setup) but not sure if it's correct.

Subgraph is at https://ios-spacex-subgraph-c17ee3a300af.herokuapp.com/graphql.