### PR TITLE
Enabling persisted queries

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,3 +18,5 @@ subscription:
       all: # The router uses these subscription settings UNLESS overridden per-subgraph
         path: /graphql # The absolute URL path to use for subgraph subscription endpoints (Default: /ws)
         protocol: graphql_ws # The WebSocket-based subprotocol to use for subscription communication (Default: graphql_ws)
+persisted_queries:
+  enabled: true


### PR DESCRIPTION
This is required to enable Part 3 of the 2024 Summit Workshop for Apollo iOS.